### PR TITLE
Upgrade nginx to 1.22

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -14,7 +14,8 @@ services:
       - db-data:/var/lib/mysql
 
   nginx:
-    image: nginx:1.19-alpine
+    build:
+      target: dev
     environment:
       VIRTUAL_HOST: testing.local
     restart: "no"

--- a/docker/nginx.Dockerfile
+++ b/docker/nginx.Dockerfile
@@ -1,4 +1,4 @@
-FROM nginx:1.19-alpine
+FROM nginx:1.22-alpine as dev
 
 WORKDIR /app/public
 


### PR DESCRIPTION
- Upgraded nginx to the latest stable version.
- Use the nginx.Dockerfile base image instead of defining the version again in docker-compose.override.yml