### PR TITLE
Fixed npm errors when running npm install during docker-compose up

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -40,7 +40,7 @@ services:
     working_dir: /app
     volumes:
       - ./:/app
-    command: sh -c "npm install && npm run watch"
+    command: sh -c "npm install"
 
   composer:
     image: composer:2

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,12 @@
 {
   "name": "app",
+  "version": "1.0.0",
   "lockfileVersion": 2,
   "requires": true,
-  "packages": {}
+  "packages": {
+    "": {
+      "name": "app",
+      "version": "1.0.0"
+    }
+  }
 }

--- a/package.json
+++ b/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "app",
+  "version": "1.0.0",
+  "dependencies": {
+  }
+}


### PR DESCRIPTION
The easiest way to fix the errors present in issue https://github.com/stephenhoult/docker-dev-env/issues/4 is to include an empty package.json file so this is what has been done.

I've also removed the `npm run watch` command as the project doesn't have this script or a javascript module bundler.